### PR TITLE
fix flag name

### DIFF
--- a/cmd/aeraki/main.go
+++ b/cmd/aeraki/main.go
@@ -34,11 +34,11 @@ import (
 )
 
 const (
-	defaultIstiodAddr = "istiod.istio-system:15010"
-	defaultNamespace  = "istio-system"
-	defaultXdsAddr    = ":15010"
-	defaultElectionID = "aeraki-controller"
-	defaultLogLevel   = "all:info"
+	defaultIstiodAddr        = "istiod.istio-system:15010"
+	defaultNamespace         = "istio-system"
+	defaultXdsAddr           = ":15010"
+	defaultElectionID        = "aeraki-controller"
+	defaultLogLevel          = "all:info"
 	defaultConfigStoreSecret = ""
 )
 
@@ -49,7 +49,7 @@ func main() {
 	flag.StringVar(&args.XdsAddr, "xds-listen-address", defaultXdsAddr, "Istiod xds server port")
 	flag.StringVar(&args.ConfigStoreSecret, "config-store-secret", defaultConfigStoreSecret,
 		"The secret to store the Istio kube config store, use the in cluster API server if it's not specified")
-	flag.StringVar(&args.ElectionID, "electionID", defaultElectionID, "ElectionID to elect master controller")
+	flag.StringVar(&args.ElectionID, "election-id", defaultElectionID, "ElectionID to elect master controller")
 	flag.StringVar(&args.LogLevel, "log-level", defaultLogLevel, "Component log level")
 	flag.Parse()
 


### PR DESCRIPTION
Use `election-id` to replace `electionID`, consistent with other flag name formats.