### PR TITLE
Consistent hash load balancing settings prioritizes dependent subsets.

### DIFF
--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -53,7 +53,7 @@ func BuildMetaProtocolRouteName(host string, port int) string {
 func GetHashPolicy(dr *DestinationRuleWrapper, subsetName string) string {
 	if subsetName == "" {
 		return getConsistentHashHeaderName(dr.Spec.TrafficPolicy)
-	} else if dr != nil && dr.Spec != nil && dr.Spec.Subsets != nil && len(dr.Spec.Subsets) > 0 {
+	} else if dr != nil && dr.Spec != nil && dr.Spec.Subsets != nil {
 		for _, subset := range dr.Spec.Subsets {
 			if subsetName == subset.GetName() {
 				return getConsistentHashHeaderName(subset.TrafficPolicy)
@@ -65,8 +65,7 @@ func GetHashPolicy(dr *DestinationRuleWrapper, subsetName string) string {
 
 // getConsistentHashHeaderName return consistent hash header in TrafficPolicy
 func getConsistentHashHeaderName(tp *networking.TrafficPolicy) string {
-	if tp != nil && tp.LoadBalancer != nil && tp.LoadBalancer.GetConsistentHash() != nil &&
-		tp.LoadBalancer.GetConsistentHash().GetHttpHeaderName() != "" {
+	if tp != nil && tp.LoadBalancer != nil && tp.LoadBalancer.GetConsistentHash() != nil {
 		return tp.LoadBalancer.GetConsistentHash().GetHttpHeaderName()
 	}
 	return ""

--- a/pkg/xds/cache_mgr.go
+++ b/pkg/xds/cache_mgr.go
@@ -112,10 +112,10 @@ func (c *CacheMgr) mainLoop(stop <-chan struct{}) {
 }
 
 func (c *CacheMgr) updateRouteCache() error {
-	//if len(c.routeCache.GetStatusKeys()) == 0 {
-	//	xdsLog.Infof("no rds subscriber, ignore this update")
-	//	return nil
-	//}
+	if len(c.routeCache.GetStatusKeys()) == 0 {
+		xdsLog.Infof("no rds subscriber, ignore this update")
+		return nil
+	}
 	serviceEntries, err := c.configStore.List(collections.IstioNetworkingV1Alpha3Serviceentries.Resource().
 		GroupVersionKind(), "")
 	if err != nil {

--- a/pkg/xds/cache_mgr.go
+++ b/pkg/xds/cache_mgr.go
@@ -116,6 +116,7 @@ func (c *CacheMgr) updateRouteCache() error {
 		xdsLog.Infof("no rds subscriber, ignore this update")
 		return nil
 	}
+
 	serviceEntries, err := c.configStore.List(collections.IstioNetworkingV1Alpha3Serviceentries.Resource().
 		GroupVersionKind(), "")
 	if err != nil {

--- a/pkg/xds/cache_mgr.go
+++ b/pkg/xds/cache_mgr.go
@@ -112,10 +112,10 @@ func (c *CacheMgr) mainLoop(stop <-chan struct{}) {
 }
 
 func (c *CacheMgr) updateRouteCache() error {
-	if len(c.routeCache.GetStatusKeys()) == 0 {
-		xdsLog.Infof("no rds subscriber, ignore this update")
-		return nil
-	}
+	//if len(c.routeCache.GetStatusKeys()) == 0 {
+	//	xdsLog.Infof("no rds subscriber, ignore this update")
+	//	return nil
+	//}
 	serviceEntries, err := c.configStore.List(collections.IstioNetworkingV1Alpha3Serviceentries.Resource().
 		GroupVersionKind(), "")
 	if err != nil {
@@ -145,7 +145,6 @@ func (c *CacheMgr) updateRouteCache() error {
 		if len(service.Hosts) > 1 {
 			xdsLog.Warnf("multiple hosts found for service: %s, only the first one will be processed", config.Name)
 		}
-
 		metaRouter, err := c.findRelatedMetaRouter(service)
 		if err != nil {
 			xdsLog.Errorf("failed to list meta router for service: %s", config.Name)
@@ -240,6 +239,10 @@ func (c *CacheMgr) constructAction(port *networking.Port,
 				Cluster: model.BuildClusterName(model.TrafficDirectionOutbound, subset,
 					host, int(dstPort)),
 			}
+			policy := model.GetHashPolicy(dr, subset)
+			if policy != "" {
+				routeAction.HashPolicy = []string{policy}
+			}
 		} else {
 			var clusters []*routev3.WeightedCluster_ClusterWeight
 			var totalWeight uint32
@@ -257,6 +260,10 @@ func (c *CacheMgr) constructAction(port *networking.Port,
 						Value: routeDestination.Weight,
 					},
 				})
+				policy := model.GetHashPolicy(dr, subset)
+				if policy != "" {
+					routeAction.HashPolicy = append(routeAction.HashPolicy, policy)
+				}
 				totalWeight += routeDestination.Weight
 			}
 			routeAction.ClusterSpecifier = &metaroute.RouteAction_WeightedClusters{
@@ -280,11 +287,6 @@ func (c *CacheMgr) constructAction(port *networking.Port,
 				},
 			}
 		}
-	}
-	if dr != nil && dr.Spec.TrafficPolicy != nil && dr.Spec.TrafficPolicy.LoadBalancer != nil && dr.Spec.TrafficPolicy.
-		LoadBalancer.GetConsistentHash() != nil && dr.Spec.TrafficPolicy.
-		LoadBalancer.GetConsistentHash().GetHttpHeaderName() != "" {
-		routeAction.HashPolicy = []string{dr.Spec.TrafficPolicy.LoadBalancer.GetConsistentHash().GetHttpHeaderName()}
 	}
 
 	return routeAction

--- a/pkg/xds/utils.go
+++ b/pkg/xds/utils.go
@@ -80,14 +80,14 @@ func metaProtocolRoute2HttpRoute(metaRoute *metaroute.RouteConfiguration) *httpr
 		}
 
 		if route.Route.HashPolicy != nil && len(route.Route.HashPolicy) > 0 {
-			routeAction.HashPolicy = []*httproute.RouteAction_HashPolicy{
-				{
+			for _, hashPolicy := range route.Route.HashPolicy {
+				routeAction.HashPolicy = append(routeAction.HashPolicy, &httproute.RouteAction_HashPolicy{
 					PolicySpecifier: &httproute.RouteAction_HashPolicy_Header_{
 						Header: &httproute.RouteAction_HashPolicy_Header{
-							HeaderName: route.Route.HashPolicy[0],
+							HeaderName: hashPolicy,
 						},
 					},
-				},
+				})
 			}
 		}
 


### PR DESCRIPTION
I found that consistent hash lb must set in dr.spec.trafficPolicy. I think we should align with istio. Consistent hash load balancing settings prioritizes dependent subsets.

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added related test cases?
* [ ] Have you modified the related document?
* [ ] Is this PR backward compatible? 