### PR TITLE
Migrate CNCF Ecosystem projects from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/common-protos/k8s.io/api/core/v1/generated.proto
+++ b/common-protos/k8s.io/api/core/v1/generated.proto
@@ -765,7 +765,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["registry.k8s.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   repeated string names = 1;
 
   // The size of the image in bytes.


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Per https://github.com/kubernetes/k8s.io/issues/4780, Kubernetes is migrating its image registry to registry.k8s.io, and this repository is impacted.

We have to update the references of k8s.gcr.io to registry.k8s.io by April 3rd to remain up-to-date.

Here's a quick search for k8s.gcr.io on this repo. [[search result]](https://github.com/search?q=org%3Adapr%20%22k8s.gcr.io%22&type=code). Note that there may be other valid references (like, in the form of generated code, etc) which we have to be aware of.

### Pre-Submission Checklist:

<!--
Please follow the Requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test cases is recommended for the feat/fix PR
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added related test cases?
* [ ] Have you modified the related document?
* [ ] Is this PR backward compatible? 