### PR TITLE
use metaprotocol-generator generatorLog

### DIFF
--- a/plugin/metaprotocol/metaprotocolproxy.go
+++ b/plugin/metaprotocol/metaprotocolproxy.go
@@ -15,8 +15,6 @@
 package metaprotocol
 
 import (
-	"fmt"
-
 	metaprotocol "github.com/aeraki-mesh/meta-protocol-control-plane-api/aeraki/meta_protocol_proxy/v1alpha"
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	envoyconfig "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -25,6 +23,11 @@ import (
 
 	"github.com/aeraki-mesh/aeraki/pkg/model"
 	metaprotocolmodel "github.com/aeraki-mesh/aeraki/pkg/model/metaprotocol"
+)
+
+const (
+	// defaultRandomSampling is the default value for metaprotocol tracing sampling
+	defaultRandomSampling = 1.0
 )
 
 func buildOutboundProxy(context *model.EnvoyFilterContext,
@@ -120,9 +123,10 @@ func configAccessLog(context *model.EnvoyFilterContext, metaProtocolProy *metapr
 
 func configTracing(context *model.EnvoyFilterContext, metaProtocolProy *metaprotocol.MetaProtocolProxy) {
 	if context.MeshConfig.Mesh().EnableTracing {
-		randomSampling := 1.0
-		fmt.Printf("%v", context.MeshConfig.Mesh().DefaultConfig.Tracing)
-		if context.MeshConfig.Mesh().DefaultConfig.Tracing != nil {
+		randomSampling := defaultRandomSampling
+		tracing := context.MeshConfig.Mesh().DefaultConfig.Tracing
+		generatorLog.Infof("MetaProtocolProxy Tracing Address: %v", tracing)
+		if tracing != nil {
 			randomSampling = context.MeshConfig.Mesh().DefaultConfig.Tracing.Sampling
 		}
 		metaProtocolProy.Tracing = &metaprotocol.Tracing{


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-Submission Checklist:

<!--
Please follow the Requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test cases is recommended for the feat/fix PR
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
```
2023-04-19T08:25:22.213465Z	info	debounce stable[1] 5: 1.000447751s since last event, 1.000458261s since last debounce
2023-04-19T08:25:22.213561Z	info	envoyfilter-controller	found generator for port: tcp-metaprotocol-dubbo
zipkin:<address:"zipkin.istio-system:9411" > zipkin:<address:"zipkin.istio-system:9411" > 2023-04-19T08:25:22.215728Z	info	envoyfilter-controller	found generator for port: tcp-metaprotocol-dubbo
zipkin:<address:"zipkin.istio-system:9411" > zipkin:<address:"zipkin.istio-system:9411" > 2023-04-19T08:25:22.242532Z	info	envoyfilter-controller	deleting EnvoyFilter: namespace: istio-system name: aeraki-inbound-org.apache.dubbo.samples.basic.api.demoservice-20880 {"kind":"EnvoyFilter","apiVersion":"networking.istio.io/v1alpha3","metadata":{"name":"aeraki-inbound-org.apache.dubbo.samples.basic.api.demoservice-20880","namespace":"istio-system","uid":"0a0ffdba-18c5-4ad6-b25d-6b8f4df1c816","resourceVersion":"38297771","generation":1,"creationTimestamp":"2023-04-19T07:41:36Z","labels":{"manager":"Aeraki"},"managedFields":[{"manager":"Aeraki","operation":"Update","apiVersion":"networking.istio.io/v1alpha3","time":"2023-04-19T07:41:36Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:manager":{}}},"f:spec":{".":{},"f:configPatches":{},"f:workloadSelector":{".":{},"f:labels":{".":{},"f:app":{}}}}}}]},"spec":{"workloadSelector":{"labels":{"app":"dubbo-sample-provider"}},"configPatches":[{"applyTo":"NETWORK_FILTER","match":{"listener":{"filterChain":{"filter":{"name":"envoy.filters.network.tcp_proxy"},"destinationPort":20880},"name":"virtualInbound"}},"patch":{"operation":"REPLACE","value":{"name":"envoy.filters.network.meta_protocol_proxy","typed_config":{"@type":"type.googleapis.com/udpa.type.v1.TypedStruct","type_url":"type.googleapis.com/aeraki.meta_protocol_proxy.v1alpha.MetaProtocolProxy","value":{"accessLog":[{"name":"envoy.access_loggers.file","typedConfig":{"@type":"type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog","logFormat":{"jsonFormat":{"application_protocol":"%REQ(X-META-PROTOCOL-APPLICATION-PROTOCOL)%","bytes_received":"%BYTES_RECEIVED%","bytes_sent":"%BYTES_SENT%","connection_termination_details":"%CONNECTION_TERMINATION_DETAILS%","downstream_local_address":"%DOWNSTREAM_LOCAL_ADDRESS%","downstream_remote_address":"%DOWNSTREAM_REMOTE_ADDRESS%","duration":"%DURATION%","request_id":"%REQ(X-REQUEST-ID)%","response_code":"%RESPONSE_CODE%","response_code_details":"%RESPONSE_CODE_DETAILS%","route_name":"%ROUTE_NAME%","start_time":"%START_TIME%","upstream_cluster":"%UPSTREAM_CLUSTER%","upstream_local_address":"%UPSTREAM_LOCAL_ADDRESS%","upstream_transport_failure_reason":"%UPSTREAM_TRANSPORT_FAILURE_REASON%"}},"path":"/dev/stdout"}}],"applicationProtocol":"dubbo","codec":{"name":"aeraki.meta_protocol.codec.dubbo"},"metaProtocolFilters":[{"name":"aeraki.meta_protocol.filters.metadata_exchange"},{"config":{"@type":"type.googleapis.com/aeraki.meta_protocol_proxy.filters.istio_stats.v1alpha.IstioStats","destinationService":"org.apache.dubbo.samples.basic.api.demoservice"},"name":"aeraki.meta_protocol.filters.istio_stats"},{"name":"aeraki.meta_protocol.filters.router"}],"routeConfig":{"name":"inbound|20880||","routes":[{"route":{"cluster":"inbound|20880||"}}]},"statPrefix":"inbound|20880||","tracing":{"clientSampling":{"value":100},"overallSampling":{"value":100},"randomSampling":{}}}}}}}]},"status":{}}
```
log of aeraki without line breaks

* [ ] Have you added related test cases?
* [ ] Have you modified the related document?
* [ ] Is this PR backward compatible? 