### PR TITLE
fix: ClusterRole webhook permissions

### DIFF
--- a/manifests/charts/aeraki/templates/clusterrole.yaml
+++ b/manifests/charts/aeraki/templates/clusterrole.yaml
@@ -63,3 +63,9 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - '*'


### PR DESCRIPTION
### What this PR does / Why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Helm chart currently does not have the correct permissions for webhooks. `k8s/aeraki.yaml` has them, so we're copying these over

https://github.com/aeraki-mesh/aeraki/blob/974bcbbf2bfbd888967559c7f45cbe9192fd9ba8/k8s/aeraki.yaml#L213C3-L218C12

### Pre-Submission Checklist:

<!--
Please follow the Requirements:
1. Use Draft if the PR is not ready to be reviewed
2. Test cases is recommended for the feat/fix PR
3. Doc is required for the feat PR
4. Use a new commit to resolve review instead of `push -f`
5. Use "request review" to notify the reviewer once you have resolved the review
-->

* [X] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added related test cases?
* [ ] Have you modified the related document?
* [X] Is this PR backward compatible? 